### PR TITLE
Fix LIBTOOL configuration for OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-LIBTOOL=libtool
+ifeq ($(shell uname),Darwin)
+  LIBTOOL ?= glibtool
+else
+  LIBTOOL ?= libtool
+endif
 
 CFLAGS?=
 


### PR DESCRIPTION
OS X libtool doesn't accept the same options as gnu libtool,  LIBTOOL must be set to glibtool for the build to work.
