### PR TITLE
Allow the user to pass flags to the linker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,13 @@ uniutil.lo: uniutil.c unibilium.h
 	$(LIBTOOL) --mode=compile --tag=CC $(CC) -I. -DTERMINFO_DIRS='$(TERMINFO_DIRS)' -Wall -std=c99 $(CFLAGS) $(CFLAGS_DEBUG) -o $@ -c $<
 
 $(LIBRARY): $(OBJECTS)
-	$(LIBTOOL) --mode=link --tag=CC $(CC) -rpath '$(LIBDIR)' -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE) -o $@ $^
+	$(LIBTOOL) --mode=link --tag=CC $(CC) $(LDFLAGS) -rpath '$(LIBDIR)' -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE) -o $@ $^
 
 tools/%: $(LIBRARY) tools/%.lo
-	$(LIBTOOL) --mode=link --tag=CC $(CC) -o $@ $^
+	$(LIBTOOL) --mode=link --tag=CC $(CC) $(LDFLAGS) -o $@ $^
 
 %.t: $(LIBRARY) %.lo
-	$(LIBTOOL) --mode=link --tag=CC $(CC) -o $@ $^
+	$(LIBTOOL) --mode=link --tag=CC $(CC) $(LDFLAGS) -o $@ $^
 
 .PHONY: build-tools
 build-tools: $(TOOLS:.c=)


### PR DESCRIPTION
We build packages with specific hardening flags enabled in Debian, but the LDFLAGS one currently aren't picked up because the Makefile doesn't pass those on to the linker.  This patch adds that support.