### PR TITLE
GNUMakefile: Give preference to environmental CFLAGS

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,3 +1,3 @@
-CFLAGS=-std=gnu99 -pedantic -Wall -Wextra -Wno-missing-field-initializers -Wundef -Wshadow -Wbad-function-cast -Wcast-align -Wwrite-strings -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Winline -Wdisabled-optimization -O2 -pipe
+CFLAGS ?= -std=gnu99 -pedantic -Wall -Wextra -Wno-missing-field-initializers -Wundef -Wshadow -Wbad-function-cast -Wcast-align -Wwrite-strings -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Winline -Wdisabled-optimization -O2 -pipe
 
 include Makefile


### PR DESCRIPTION
Using “CFLAGS = …” only allows overrides on the command line (e.g. “make
CFLAGS="…"”).  Changing this to “CFLAGS ?= …” allows any user-provided
CFLAGS to override.