### PR TITLE
doc/unibi_{get,set}_ext_*_name: Fix man's “can't break line” warnings

### DIFF
--- a/doc/unibi_get_ext_bool_name.pod
+++ b/doc/unibi_get_ext_bool_name.pod
@@ -23,10 +23,9 @@ I<i> is the index of the extended capability to act on; it must be less than
 C<unibi_count_ext_bool(ut)>, C<unibi_count_ext_num(ut)>, or
 C<unibi_count_ext_str(ut)>, respectively.
 
-Note that
-C<unibi_set_ext_bool_name>/C<unibi_set_ext_num_name>/C<unibi_set_ext_str_name>
-simply store the pointer they are given; they will not free I<s> or make a
-copy of the string.
+Note that C<unibi_set_ext_bool_name>, C<unibi_set_ext_num_name>, and
+C<unibi_set_ext_str_name> simply store the pointer they are given; they will
+not free I<s> or make a copy of the string.
 
 =head1 SEE ALSO
 

--- a/doc/unibi_get_ext_num_name.pod
+++ b/doc/unibi_get_ext_num_name.pod
@@ -23,10 +23,9 @@ I<i> is the index of the extended capability to act on; it must be less than
 C<unibi_count_ext_bool(ut)>, C<unibi_count_ext_num(ut)>, or
 C<unibi_count_ext_str(ut)>, respectively.
 
-Note that
-C<unibi_set_ext_bool_name>/C<unibi_set_ext_num_name>/C<unibi_set_ext_str_name>
-simply store the pointer they are given; they will not free I<s> or make a
-copy of the string.
+Note that C<unibi_set_ext_bool_name>, C<unibi_set_ext_num_name>, and
+C<unibi_set_ext_str_name> simply store the pointer they are given; they will
+not free I<s> or make a copy of the string.
 
 =head1 SEE ALSO
 

--- a/doc/unibi_get_ext_str_name.pod
+++ b/doc/unibi_get_ext_str_name.pod
@@ -23,10 +23,9 @@ I<i> is the index of the extended capability to act on; it must be less than
 C<unibi_count_ext_bool(ut)>, C<unibi_count_ext_num(ut)>, or
 C<unibi_count_ext_str(ut)>, respectively.
 
-Note that
-C<unibi_set_ext_bool_name>/C<unibi_set_ext_num_name>/C<unibi_set_ext_str_name>
-simply store the pointer they are given; they will not free I<s> or make a
-copy of the string.
+Note that C<unibi_set_ext_bool_name>, C<unibi_set_ext_num_name>, and
+C<unibi_set_ext_str_name> simply store the pointer they are given; they will
+not free I<s> or make a copy of the string.
 
 =head1 SEE ALSO
 

--- a/doc/unibi_set_ext_bool_name.pod
+++ b/doc/unibi_set_ext_bool_name.pod
@@ -23,10 +23,9 @@ I<i> is the index of the extended capability to act on; it must be less than
 C<unibi_count_ext_bool(ut)>, C<unibi_count_ext_num(ut)>, or
 C<unibi_count_ext_str(ut)>, respectively.
 
-Note that
-C<unibi_set_ext_bool_name>/C<unibi_set_ext_num_name>/C<unibi_set_ext_str_name>
-simply store the pointer they are given; they will not free I<s> or make a
-copy of the string.
+Note that C<unibi_set_ext_bool_name>, C<unibi_set_ext_num_name>, and
+C<unibi_set_ext_str_name> simply store the pointer they are given; they will
+not free I<s> or make a copy of the string.
 
 =head1 SEE ALSO
 

--- a/doc/unibi_set_ext_num_name.pod
+++ b/doc/unibi_set_ext_num_name.pod
@@ -23,10 +23,9 @@ I<i> is the index of the extended capability to act on; it must be less than
 C<unibi_count_ext_bool(ut)>, C<unibi_count_ext_num(ut)>, or
 C<unibi_count_ext_str(ut)>, respectively.
 
-Note that
-C<unibi_set_ext_bool_name>/C<unibi_set_ext_num_name>/C<unibi_set_ext_str_name>
-simply store the pointer they are given; they will not free I<s> or make a
-copy of the string.
+Note that C<unibi_set_ext_bool_name>, C<unibi_set_ext_num_name>, and
+C<unibi_set_ext_str_name> simply store the pointer they are given; they will
+not free I<s> or make a copy of the string.
 
 =head1 SEE ALSO
 

--- a/doc/unibi_set_ext_str_name.pod
+++ b/doc/unibi_set_ext_str_name.pod
@@ -23,10 +23,9 @@ I<i> is the index of the extended capability to act on; it must be less than
 C<unibi_count_ext_bool(ut)>, C<unibi_count_ext_num(ut)>, or
 C<unibi_count_ext_str(ut)>, respectively.
 
-Note that
-C<unibi_set_ext_bool_name>/C<unibi_set_ext_num_name>/C<unibi_set_ext_str_name>
-simply store the pointer they are given; they will not free I<s> or make a
-copy of the string.
+Note that C<unibi_set_ext_bool_name>, C<unibi_set_ext_num_name>, and
+C<unibi_set_ext_str_name> simply store the pointer they are given; they will
+not free I<s> or make a copy of the string.
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
As shown by
“env MANWIDTH=80 man -l <(pod2man doc/unibi_set_ext_num_name.pod) >/dev/null”
man complains about not being able to break a line in the converted man
pages.  This is due to the concatenation of multiple function names
together without a wrap point.  Changing the “/” to a comma separated
list, as already done in the previous paragraph, fixes the warning.