### PR TITLE
Add Windows support in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,11 @@ INCDIR=$(PREFIX)/include
 MANDIR=$(PREFIX)/share/man
 MAN3DIR=$(MANDIR)/man3
 
-TERMINFO_DIRS="/etc/terminfo:/lib/terminfo:/usr/share/terminfo:/usr/lib/terminfo:/usr/local/share/terminfo:/usr/local/lib/terminfo"
+ifneq ($(OS),Windows_NT)
+  TERMINFO_DIRS="/etc/terminfo:/lib/terminfo:/usr/share/terminfo:/usr/lib/terminfo:/usr/local/share/terminfo:/usr/local/lib/terminfo"
+else
+  TERMINFO_DIRS=""
+endif
 
 POD2MAN=pod2man
 POD2MAN_OPTS=-c "$(PACKAGE)" -s3 -r "$(PACKAGE)-$(PKG_VERSION)"


### PR DESCRIPTION
Cheers I have some minimal fixes to enable building with MinGW-w64
- Use separate CFLAGS for windows, disable use of ASAN and stack protection
  options in Windows builds MinGW-w64 does not support them.
- Set TERMINFO_DIRS as empty.

Not sure what else to do about TERMINFO_DIRS, since there is no sensible default.
