### PR TITLE
Do not force install dirs, add question mark assignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,12 @@ LT_REVISION=0
 LT_CURRENT=4
 LT_AGE=0
 
-PREFIX=/usr/local
-LIBDIR=$(PREFIX)/lib
-INCDIR=$(PREFIX)/include
-MANDIR=$(PREFIX)/share/man
-MAN3DIR=$(MANDIR)/man3
+PREFIX?=/usr/local
+LIBDIR?=$(PREFIX)/lib
+INCDIR?=$(PREFIX)/include
+SHAREDIR?=$(PREFIX)/share
+MANDIR?=$(SHAREDIR)/man
+MAN3DIR?=$(MANDIR)/man3
 
 ifneq ($(OS),Windows_NT)
   TERMINFO_DIRS="$(shell ncursesw6-config --terminfo-dirs 2>/dev/null || \


### PR DESCRIPTION
It would be useful to set the *DIR variables directly from make,
but this is not possible unless question marks are added to the
assignments. Also, MANDIR should be based on SHAREDIR, since
SHAREDIR may not always be at $(PREFIX)/share.