### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ PREFIX=/usr/local
 LIBDIR=$(PREFIX)/lib
 INCDIR=$(PREFIX)/include
 SHAREDIR=$(PREFIX)/share
-MANDIR=$(SHAREDIR)man
+MANDIR=$(SHAREDIR)/man
 MAN3DIR=$(MANDIR)/man3
 
 ifneq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ LT_AGE=0
 PREFIX=/usr/local
 LIBDIR=$(PREFIX)/lib
 INCDIR=$(PREFIX)/include
-MANDIR=$(PREFIX)/share/man
+SHAREDIR=$(PREFIX)/share
+MANDIR=$(SHAREDIR)man
 MAN3DIR=$(MANDIR)/man3
 
 ifneq ($(OS),Windows_NT)


### PR DESCRIPTION
Some use cases require SHAREDIR to be in a unrelated location from the PREFIX