### PR TITLE
Stop searching in further dirs on errors except ENOENT

### DIFF
--- a/uniutil.c
+++ b/uniutil.c
@@ -157,7 +157,7 @@ static unibi_term *from_dirs(const char *list, const char *term) {
         z = strchr(a, ':');
 
         ut = from_dir(a, z, NULL, term);
-        if (ut) {
+        if (ut || errno != ENOENT) {
             return ut;
         }
 
@@ -188,7 +188,7 @@ unibi_term *unibi_from_term(const char *term) {
 
     if ((env = getenv("HOME"))) {
         ut = from_dir(env, NULL, ".terminfo", term);
-        if (ut) {
+        if (ut || errno != ENOENT) {
             return ut;
         }
     }


### PR DESCRIPTION
I don't know if it was intentional, but if a terminfo file was found during the directory search, loaded, and then found to contain an error, the search continues into other locations. If this eventually fails, the error is always `ENOENT`, thus swallowing the reason that the file which was found, had errored.

This PR changes the behaviour, stopping on the first error that is not `ENOENT`.